### PR TITLE
Add timeouts to deferred rendering

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "port": 3000,
-  "document_path": "./document"
+  "document_path": "./document",
+  "render_timeout": 30000
 }

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ function render(data) {
                 resolve();
                 res.status(200).end();
             });
+
+            setTimeout(function() {
+              reject(new Error('Deferred rendering has exceeded the timeout'));
+            }, config.render_timeout);
         });
         res.status(200).end();
     });
@@ -102,6 +106,9 @@ app.post('/render', function (req, res) {
                 log('debug', 'Removed local file after serving to the client: ' + output);
             });
         });
+    }).catch(function errored(reason) {
+      log('error', 'Rendering has encountered an error: ' + reason);
+      res.status(500).send(reason);
     });
 });
 


### PR DESCRIPTION
Gennie can hang indefinitely if the template has requested deferred rendering, but does not call `done`. This PR fixes that by giving templates an upper time limit before rejecting the rendering.

@inventid/tech please review!
